### PR TITLE
Preferred names and pronouns

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,8 @@ class BaseModel(Model):
 
 class Worker(BaseModel):
     name = CharField()
+    preferred_name = CharField(null=True)
+    pronouns = CharField(null=True)
     email = CharField(unique=True, null=True)
     phone = IntegerField(unique=True, null=True)
     notes = TextField(null=True)

--- a/main.py
+++ b/main.py
@@ -264,6 +264,8 @@ def workers_edit(worker_id):
     if request.method == "POST":
         Worker.update(
             {
+                Worker.preferred_name: request.form["preferred_name"],
+                Worker.pronouns: request.form["pronouns"],
                 Worker.email: request.form["email"],
                 Worker.phone: request.form["phone"],
                 Worker.notes: request.form["notes"],

--- a/main.py
+++ b/main.py
@@ -269,7 +269,7 @@ def workers_edit(worker_id):
                 Worker.email: request.form["email"],
                 Worker.phone: request.form["phone"],
                 Worker.notes: request.form["notes"],
-                Worker.active: request.form["active"],
+                Worker.active: bool(request.form.get("active")),
             }
         ).where(Worker.id == worker_id).execute()
         flash("Worker data updated")

--- a/main.py
+++ b/main.py
@@ -269,6 +269,7 @@ def workers_edit(worker_id):
                 Worker.email: request.form["email"],
                 Worker.phone: request.form["phone"],
                 Worker.notes: request.form["notes"],
+                Worker.active: request.form["active"],
             }
         ).where(Worker.id == worker_id).execute()
         flash("Worker data updated")

--- a/templates/workers_edit.html
+++ b/templates/workers_edit.html
@@ -26,6 +26,10 @@
 	<label for="notes">Notes</label>
 	<textarea name="notes">{{ worker.notes or "" }}</textarea>
 	</p>
+	<p>
+	<label for="active">Active (uncheck if worker graduated or is otherwise not currently associated with the university)</label>
+	<input name="active" type="checkbox" value=True {{'checked="checked"' if worker.active else ""}}/>
+	</p>
 	<input type="submit" value="Update data" />
 </form>
 {% endblock %}

--- a/templates/workers_edit.html
+++ b/templates/workers_edit.html
@@ -7,6 +7,14 @@
 	</h3>
 	<p>
 	<p>Added since {{ worker.added }}, last known contract from {{ worker.updated }}<p>
+	<p>
+	<label for="preferred_name">Preferred name</label>
+	<input name="preferred_name" type="text" value="{{ worker.preferred_name or worker.name }}" />
+	</p>
+	<p>
+	<label for="pronouns">Pronouns</label>
+	<input name="pronouns" type="text" value="{{ worker.pronouns or ""}}" placeholder="gender is a spectrum" />
+	</p>
 	<label for="email">E-Mail</label>
 	<input name="email" type="text" value="{{ worker.email or "" }}" placeholder="worker@email.com" />
 	</p>


### PR DESCRIPTION
Adds preferred names and pronouns to the database as well as the worker interface. Both are not required but will help us keep track of important information about membership. 

I think most personal information can be added to the Notes, but I wanted this information to be easy to find and obvious.