### PR TITLE
codecov.yml: add configuration for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Add configuration file for codecov.

For now, it is in 'informational' mode which just means that it will display the coverage without affecting our ability to merge PRs. Later, we can set thresholds when adding new commits to ensure that new code is covered so we don't fall behind on testing.