### PR TITLE
CI: publish package on release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Upload Python Package
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Set __version__ and poetry version
+        run: |
+          TAG="$(git describe --tags --abbrev=0)"
+          poetry version "${TAG##*v}"
+
+      - name: Build and publish
+        run: |
+          poetry build
+          poetry publish \
+            --username ${{ secrets.PYPI_USERNAME }} \
+            --password ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Upload wallchart package to PyPi using GitHub actions.

@runburg please create an account on PyPi and add username/password/token as secrets called `PYPI_USERNAME` and `PYPI_PASSWORD`.

Signed-off-by: Paul Spooren <mail@aparcar.org>